### PR TITLE
Get result from which/where first

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,8 +64,16 @@ const getPathFromExecutableNameOnWindows = (packageName, executableName) => {
 			const pathToExecutable = line && line.trim(),
 				pathToLib = pathToExecutable && path.join(path.dirname(pathToExecutable), nodeModulesDirName, packageName);
 
-			if (pathToLib && fs.existsSync(pathToLib)) {
-				return pathToLib;
+			if (pathToLib) {
+				if (fs.existsSync(pathToLib)) {
+					return pathToLib;
+				}
+
+				// In case the path to <package>/bin/ is added to the PATH
+				const resolvedPath = getPathWhenExecutableIsAddedDirectlyToPath(packageName, pathToExecutable);
+				if (resolvedPath) {
+					return resolvedPath;
+				}
 			}
 		}
 	} catch (err) {
@@ -100,9 +108,24 @@ const getPathFromExecutableNameOnNonWindows = (packageName, executableName) => {
 					return packagePathMatch[1];
 				}
 			}
+
+			// In case executable is added to PATH directly
+			return getPathWhenExecutableIsAddedDirectlyToPath(packageName, whichResult);
 		}
 	} catch (err) {
 		console.error(err.message);
+	}
+
+	return null;
+};
+
+const getPathWhenExecutableIsAddedDirectlyToPath = (packageName, executablePath) => {
+	const pathToPackageJson = path.join(path.dirname(executablePath), "..", "package.json");
+	if (fs.existsSync(pathToPackageJson)) {
+		const packageNameFromPackageJson = JSON.parse(fs.readFileSync(pathToPackageJson)).name;
+		if (packageNameFromPackageJson === packageName) {
+			return path.dirname(pathToPackageJson);
+		}
 	}
 
 	return null;
@@ -117,19 +140,18 @@ const getPath = (packageName, executableName) => {
 		throw new Error(`OS '${platform}' is not supported.'`);
 	}
 
-	const resultWithNpmConfig = getPathFromNpmConfig(platform, packageName);
-
-	if (resultWithNpmConfig) {
-		return resultWithNpmConfig;
-	}
-
+	let foundPath = null;
 	if (executableName) {
-		return platform === "win32" ?
+		foundPath = platform === "win32" ?
 			getPathFromExecutableNameOnWindows(packageName, executableName) :
 			getPathFromExecutableNameOnNonWindows(packageName, executableName);
 	}
 
-	return null;
+	if (!foundPath) {
+		foundPath = getPathFromNpmConfig(platform, packageName);
+	}
+
+	return foundPath;
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-modules-path",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Returns path to globally installed package",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
Get the result from which/where output first instead of the result from npm globally installed modules.
This is required in cases where the searched package is added to PATH from different place.