### PR TITLE
feat: Add support for yarn on  Windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,25 +48,62 @@ const getPathFromNpmConfig = (platform, packageName) => {
 		}
 
 		const packagePath = path.join(nodeModulesPath, packageName);
-
-		if (fs.existsSync(packagePath)) {
-			return packagePath;
+		const verifiedPath = getVerifiedPath(packagePath, packageName);
+		if (verifiedPath) {
+			return verifiedPath;
 		}
 	}
 
 	return null;
 };
 
+const getPathFromCmdContent = (packageName, pathToExecutable) => {
+	if (fs.existsSync(pathToExecutable)) {
+		const windowsPathRegExp = /(%~dp0[\w\\\.-]+node_modules).*?"/g;
+		const executableContent = fs.readFileSync(pathToExecutable).toString();
+		const match = windowsPathRegExp.exec(executableContent);
+
+		if (match && match[1]) {
+			const realPath = path.normalize(match[1].replace("%~dp0", path.dirname(pathToExecutable)));
+			const pathToPackage = getVerifiedPath(path.join(realPath, packageName), packageName);
+			if (pathToPackage) {
+				return pathToPackage;
+			}
+		}
+	}
+};
+
+const getVerifiedPath = (suggestedPath, packageName) => {
+	const pathToPackageJson = path.join(suggestedPath, "package.json");
+	if (fs.existsSync(suggestedPath) && fs.existsSync(pathToPackageJson)) {
+		try {
+			const packageJsonContent = JSON.parse(fs.readFileSync(pathToPackageJson));
+			if (packageJsonContent.name === packageName) {
+				return suggestedPath;
+			}
+		} catch (err) {
+			// do nothing
+		}
+	}
+};
+
 const getPathFromExecutableNameOnWindows = (packageName, executableName) => {
 	try {
 		const whereResult = (childProcess.execSync(`where ${executableName}`) || "").toString().split("\n");
 		for (const line of whereResult) {
-			const pathToExecutable = line && line.trim(),
-				pathToLib = pathToExecutable && path.join(path.dirname(pathToExecutable), nodeModulesDirName, packageName);
+			const pathToExecutable = line && line.trim();
 
-			if (pathToLib) {
-				if (fs.existsSync(pathToLib)) {
-					return pathToLib;
+			if (pathToExecutable) {
+				const pathToLib = path.join(path.dirname(pathToExecutable), nodeModulesDirName, packageName);
+				const verifiedPath = getVerifiedPath(pathToLib, packageName);
+				if (verifiedPath) {
+					return verifiedPath;
+				}
+
+				// consider checking the content of the file - in most of the cases it contains the real path to the executable.
+				const pathToExecutableFromContent = getPathFromCmdContent(packageName, pathToExecutable);
+				if (pathToExecutableFromContent) {
+					return pathToExecutableFromContent;
 				}
 
 				// In case the path to <package>/bin/ is added to the PATH
@@ -105,7 +142,10 @@ const getPathFromExecutableNameOnNonWindows = (packageName, executableName) => {
 				const packagePathMatch = pathToRealExecutable.match(new RegExp(`(.*?${path.join(nodeModulesDirName, packageName)}).*$`));
 
 				if (packagePathMatch) {
-					return packagePathMatch[1];
+					const verifiedPath = getVerifiedPath(packagePathMatch[1], packageName);
+					if (verifiedPath) {
+						return verifiedPath;
+					}
 				}
 			}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ const getPathFromNpmConfig = (platform, packageName) => {
 
 const getPathFromCmdContent = (packageName, pathToExecutable) => {
 	if (fs.existsSync(pathToExecutable)) {
-		const windowsPathRegExp = /(%~dp0[\w\\\.-]+node_modules).*?"/g;
+		const windowsPathRegExp = /(%~dp0[\w\\.-]+node_modules).*?"/g;
 		const executableContent = fs.readFileSync(pathToExecutable).toString();
 		const match = windowsPathRegExp.exec(executableContent);
 


### PR DESCRIPTION
Currently the package works incorrectly when Yarn is used to install packages globally on Windows. Yarn uses different structure of placing executables and content of packages. In order to handle it, just parse
the `.cmd` executable and search for `node_modules` in it. The file should contain some special symbols describing the current directory `%~dp0` followed by `node_modules` at some point. This is the real path
to the executable and it should always be correct. Replace the special symbols with the real path and check if this is the package we are looking for. Add additional check in the code to verify that the returned directory contains package.json file with the same name that is required by the caller.

Fixes https://github.com/rosen-vladimirov/global-modules-path/issues/3

NOTE: Tests needs to be rewritten to share more code, but this will be handled in separate PR.