### PR TITLE
Fix support for [installation_folder_path]/bin in PATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ build/Release
 # Dependency directories
 node_modules
 jspm_packages
+package-lock.json
 
 # Optional npm cache directory
 .npm

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,13 +59,31 @@ const getPathFromNpmConfig = (platform, packageName) => {
 
 const getPathFromCmdContent = (packageName, pathToExecutable) => {
 	if (fs.existsSync(pathToExecutable)) {
-		const windowsPathRegExp = /(%~dp0[\w\\.-]+node_modules).*?"/g;
 		const executableContent = fs.readFileSync(pathToExecutable).toString();
-		const match = windowsPathRegExp.exec(executableContent);
+
+		let fullPath;
+
+		let windowsPathRegExp = /(%~dp0[\w\\.-]+node_modules).*?"/g;
+		let match = windowsPathRegExp.exec(executableContent);
 
 		if (match && match[1]) {
 			const realPath = path.normalize(match[1].replace("%~dp0", path.dirname(pathToExecutable)));
-			const pathToPackage = getVerifiedPath(path.join(realPath, packageName), packageName);
+
+			fullPath = path.join(realPath, packageName);
+		}
+
+		if (!fullPath) {
+			windowsPathRegExp = new RegExp(`(%~dp0[\\w\\\\.-]+?${packageName})(?:\\\\|")`, "g");
+			match = windowsPathRegExp.exec(executableContent);
+
+			if (match && match[1]) {
+				fullPath = path.normalize(match[1].replace("%~dp0", path.dirname(pathToExecutable)));
+			}
+		}
+
+		if (fullPath) {
+			const pathToPackage = getVerifiedPath(fullPath, packageName);
+
 			if (pathToPackage) {
 				return pathToPackage;
 			}


### PR DESCRIPTION
In you install NS CLI in a folder and then add [installation_folder_path]/node_modules/.bin to PATH, getPath should still return the path to that module.