### PR TITLE
Handle symlinks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -199,6 +199,7 @@ const getPath = (packageName, executableName) => {
 	}
 
 	let foundPath = null;
+
 	if (executableName) {
 		foundPath = platform === "win32" ?
 			getPathFromExecutableNameOnWindows(packageName, executableName) :
@@ -207,6 +208,14 @@ const getPath = (packageName, executableName) => {
 
 	if (!foundPath) {
 		foundPath = getPathFromNpmConfig(platform, packageName);
+	}
+
+	if (foundPath) {
+		try {
+			foundPath = fs.realpathSync(foundPath);
+		} catch (err) {
+			console.error(err.message);
+		}
 	}
 
 	return foundPath;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-modules-path",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Returns path to globally installed package",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
In case you have a locally installed package and add a symlink in the global NPM folder, getPath should return the real path to the package.