### PR TITLE
fix: do not allow command injection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,9 +25,26 @@ const getNpmExecutable = (platform) => {
 	return npmExecutableName;
 };
 
+const spawnSyncWrapper = (command, commandArgs) => {
+	const result = childProcess.spawnSync(command, commandArgs);
+	if (!result) {
+		return null;
+	}
+
+	if (result.error) {
+		throw result.error;
+	}
+
+	if (result.stdout) {
+		return result.stdout.toString().trim();
+	}
+
+	return null;
+};
+
 const getNpmPrefix = (pathToNpm) => {
 	try {
-		const npmPrefixStdout = childProcess.execSync(`${pathToNpm} config get prefix`);
+		const npmPrefixStdout = spawnSyncWrapper(pathToNpm, ["config", "get", "prefix"]);
 		return npmPrefixStdout && npmPrefixStdout.toString().trim();
 	} catch (err) {
 		console.error(err.message);
@@ -49,6 +66,7 @@ const getPathFromNpmConfig = (platform, packageName) => {
 
 		const packagePath = path.join(nodeModulesPath, packageName);
 		const verifiedPath = getVerifiedPath(packagePath, packageName);
+
 		if (verifiedPath) {
 			return verifiedPath;
 		}
@@ -107,7 +125,8 @@ const getVerifiedPath = (suggestedPath, packageName) => {
 
 const getPathFromExecutableNameOnWindows = (packageName, executableName) => {
 	try {
-		const whereResult = (childProcess.execSync(`where ${executableName}`) || "").toString().split("\n");
+		const whereResult = (spawnSyncWrapper("where", executableName) || "").split("\n");
+
 		for (const line of whereResult) {
 			const pathToExecutable = line && line.trim();
 
@@ -145,8 +164,8 @@ const getPathFromExecutableNameOnNonWindows = (packageName, executableName) => {
 
 		// whichResult: /usr/local/nvm/versions/node/v4.2.1/bin/mobile-cli-lib
 		// lsLResult: lrwxrwxrwx 1 rvladimirov rvladimirov 52 Oct 20 14:51 /usr/local/nvm/versions/node/v4.2.1/bin/mobile-cli-lib -> ../lib/node_modules/mobile-cli-lib/bin/common-lib.js
-		const whichResult = (childProcess.execSync(`which ${executableName}`) || "").toString().trim(),
-			lsLResult = (childProcess.execSync(`ls -l \`which ${executableName}\``) || "").toString().trim();
+		const whichResult = spawnSyncWrapper("which", [executableName]);
+		const lsLResult = spawnSyncWrapper("ls", ["-l", whichResult]);
 
 		if (whichResult && lsLResult) {
 			const regex = new RegExp(`${whichResult}\\s+->\\s+(.*?)$`),


### PR DESCRIPTION
Due to usage of execSync, callers may inject commands, like getPath("something & touch abc", "somethingElse & touch def"). To fix this, replace execSync with spawnSync, which is safe for command injection.